### PR TITLE
stake-pool: Update devnet program address

### DIFF
--- a/docs/content/docs/stake-pool/cli.md
+++ b/docs/content/docs/stake-pool/cli.md
@@ -59,7 +59,7 @@ to activate and deactivate, you can run the stake pool locally using the
 from devnet.
 
 ```console
-$ solana-test-validator -c SPoo1Ku8WFXoNDMHPsrGSTSG1Y47rzgn41SLUNakuHy -c EmiU8AQkB2sswTxVB6aCmsAJftoowZGGDXuytm6X65R3 --url devnet --slots-per-epoch 32
+$ solana-test-validator --clone-upgradeable-program SPoo1Ku8WFXoNDMHPsrGSTSG1Y47rzgn41SLUNakuHy --url mainnet-beta --slots-per-epoch 32
 $ solana config set --url http://127.0.0.1:8899
 ```
 

--- a/docs/content/docs/stake-pool/index.md
+++ b/docs/content/docs/stake-pool/index.md
@@ -12,9 +12,12 @@ to maximize censorship resistance and rewards.
 | Testnet | `SPoo1Ku8WFXoNDMHPsrGSTSG1Y47rzgn41SLUNakuHy` |
 | Devnet | `DPoo15wWDqpPJJtS2MUZ49aRxqz5ZaaJCJP4z8bLuib` |
 
-NOTE: The devnet deployment of the program still uses v0.6.4, and is not suitable
-for testing. For testing, it is recommended to use testnet, a local test validator,
-or deploy your own version for devnet.
+NOTE: The devnet deployment of the program at address
+`SPoo1Ku8WFXoNDMHPsrGSTSG1Y47rzgn41SLUNakuHy` is still on v0.6.4, and is not
+suitable for testing. The program at address
+`DPoo15wWDqpPJJtS2MUZ49aRxqz5ZaaJCJP4z8bLuib` mirrors the program deployed to
+mainnet-beta, and should be used instead. The CLI and JS library will
+automatically use the latter address when targeting the devnet RPC.
 
 ## Getting Started
 

--- a/docs/content/docs/stake-pool/index.md
+++ b/docs/content/docs/stake-pool/index.md
@@ -6,9 +6,11 @@ A program for pooling together SOL to be staked by an off-chain agent running
 a Delegation Bot which redistributes the stakes across the network and tries
 to maximize censorship resistance and rewards.
 
-| Information | Account Address |
+| Network | Account Address |
 | --- | --- |
-| Stake Pool Program | `SPoo1Ku8WFXoNDMHPsrGSTSG1Y47rzgn41SLUNakuHy` |
+| Mainnet-beta | `SPoo1Ku8WFXoNDMHPsrGSTSG1Y47rzgn41SLUNakuHy` |
+| Testnet | `SPoo1Ku8WFXoNDMHPsrGSTSG1Y47rzgn41SLUNakuHy` |
+| Devnet | `DPoo15wWDqpPJJtS2MUZ49aRxqz5ZaaJCJP4z8bLuib` |
 
 NOTE: The devnet deployment of the program still uses v0.6.4, and is not suitable
 for testing. For testing, it is recommended to use testnet, a local test validator,


### PR DESCRIPTION
#### Problem

The devnet stake pool program address is different because we lost the old upgrade keys. To get around that, we've deployed to a new address, but it isn't documented.

#### Summary of changes

Document the program address to use on all networks.