### PR TITLE
token-2022: Add upated docs for new (and some old) extensions

### DIFF
--- a/docs/content/docs/token-2022/extensions.mdx
+++ b/docs/content/docs/token-2022/extensions.mdx
@@ -2222,15 +2222,18 @@ Coming soon!
 
 ### Scaled UI Amount
 
-Tokens whose value can change in value have many uses in the real world. For
-example, a stock split creates many new shares for holders, but it is
-impractical for a decentralized blockchain token to mint new tokens to all
-holders during a split event.
+Tokens that can programmatically update amounts uniformly for all users
+simultaneously have many use cases in the real world. For example, a stock split
+doubles the number of shares for all holders. Due to the cost and additional
+complexity, it is currently impractical to mint new tokens to all holders during
+a split event.
 
 With the Token-2022 extension model, however, we have the possibility to change
 how the UI amount of tokens are represented. Using the `ScaledUiAmount`
 extension and the `amount_to_ui_amount` instruction, you can set a UI multiplier
 on your token and fetch its UI amount at any time.
+
+This feature can also be used for dividends or distributing yield.
 
 **Note**: No new tokens are ever created, the UI amount returns the raw amount
 of tokens multiplied by the current multiplier. The feature is entirely cosmetic.

--- a/docs/content/docs/token-2022/extensions.mdx
+++ b/docs/content/docs/token-2022/extensions.mdx
@@ -2337,3 +2337,119 @@ Signature: 5DQs6hzkfGq3uotESuVwF7MGeMawwfQcm1e9RHaUeVySDV6xpUzYhzdb6ygqJfsEZqewg
 
   </Tab>
 </Tabs>
+
+### Pausable
+
+Token systems on many blockchains and even some traditional finance
+applications have the ability to "pause" all activity. During this time, it is
+not possible transfer, mint, or burn tokens. The Token-2022 program contains an
+extension to enable this behavior.
+
+By enabling the pausable extension on your mint, the program aborts all tranfers,
+mints, and burns when the `paused` flag is flipped.
+
+#### Example: Create a pausable mint
+
+<Tabs groupId="language" items={['CLI', 'JS']}>
+  <Tab value="CLI">
+
+```console
+$ spl-token --program-id TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb create-token --enable-pause
+Creating token HpSvH8DWiGi2Y4dkGqymdWhjBk5sPj933BkuJSu5b9rU under program TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb
+
+Address:  HpSvH8DWiGi2Y4dkGqymdWhjBk5sPj933BkuJSu5b9rU
+Decimals:  9
+
+Signature: 3AFUqZfodv1GRxsDpmkbyTXqPypf4bWd7A1E3X5ZstcTodAQVVEwvkq7UHHY9fZXViUFgVuPXJXrPZtM8MvFcKRN
+```
+
+  </Tab>
+  <Tab value="JS">
+
+```jsx
+import {
+    clusterApiUrl,
+    Connection,
+    Keypair,
+    sendAndConfirmTransaction,
+    SystemProgram,
+    Transaction,
+    LAMPORTS_PER_SOL
+} from '@solana/web3.js';
+import {
+    createInitializeMintInstruction,
+    createInitializePausableConfigInstruction,
+    getMintLen,
+    pause,
+    resume,
+    ExtensionType,
+    TOKEN_2022_PROGRAM_ID
+} from '../src';
+
+(async () => {
+    const connection = new Connection(clusterApiUrl('devnet'), 'confirmed');
+
+    const payer = Keypair.generate();
+    const airdropSignature = await connection.requestAirdrop(payer.publicKey, 2 * LAMPORTS_PER_SOL);
+    await connection.confirmTransaction({ signature: airdropSignature, ...(await connection.getLatestBlockhash()) });
+
+    const mintKeypair = Keypair.generate();
+    const decimals = 9;
+    const mintLen = getMintLen([ExtensionType.PausableConfig]);
+    const lamports = await connection.getMinimumBalanceForRentExemption(mintLen);
+    const transaction = new Transaction().add(
+        SystemProgram.createAccount({
+            fromPubkey: payer.publicKey,
+            newAccountPubkey: mintKeypair.publicKey,
+            space: mintLen,
+            lamports,
+            programId: TOKEN_2022_PROGRAM_ID,
+        }),
+        createInitializePausableConfigInstruction(mintKeypair.publicKey, payer.publicKey, TOKEN_2022_PROGRAM_ID),
+        createInitializeMintInstruction(mintKeypair.publicKey, decimals, payer.publicKey, payer.publicKey, TOKEN_2022_PROGRAM_ID),
+    );
+    await sendAndConfirmTransaction(connection, transaction, [payer, mintKeypair]);
+})();
+```
+
+  </Tab>
+</Tabs>
+
+#### Example: Pausing or resuming a mint
+
+The pause authority may always choose to pause or unpause activity on the mint.
+
+<Tabs groupId="language" items={['CLI', 'JS']}>
+  <Tab value="CLI">
+
+```console
+$ spl-token pause HpSvH8DWiGi2Y4dkGqymdWhjBk5sPj933BkuJSu5b9rU
+Pausing mint, burn, and transfer for HpSvH8DWiGi2Y4dkGqymdWhjBk5sPj933BkuJSu5b9rU
+
+Signature: MBnzmsMUuwXQBQo4oLSt8wyv7Fq8GTzqTSzk9KKM9LEgjRadhqimgHGq1JU4MtpLq1BsFfBGfWkHDVhgvYA4mCs
+
+$ spl-token resume HpSvH8DWiGi2Y4dkGqymdWhjBk5sPj933BkuJSu5b9rU
+Resuming mint, burn, and transfer for HpSvH8DWiGi2Y4dkGqymdWhjBk5sPj933BkuJSu5b9rU
+
+Signature: 5A5frazN9VzMP5KiGGLNmXxE3gUJAptsbFweEyUdiFg7T2SsneVHSQvYT9ABR99uu5RjJ9fHNswBgWx8MQb7aVjD
+```
+
+  </Tab>
+  <Tab value="JS">
+
+```jsx
+    await pause(
+        connection,
+        payer,
+        mintKeypair.publicKey,                                                                    payer,
+    );
+    await resume(
+        connection,
+        payer,
+        mintKeypair.publicKey,
+        payer,
+    );
+```
+
+  </Tab>
+</Tabs>

--- a/docs/content/docs/token-2022/extensions.mdx
+++ b/docs/content/docs/token-2022/extensions.mdx
@@ -2219,3 +2219,121 @@ Coming soon!
 
   </Tab>
 </Tabs>
+
+### Scaled UI Amount
+
+Tokens whose value can change in value have many uses in the real world. For
+example, a stock split creates many new shares for holders, but it is
+impractical for a decentralized blockchain token to mint new tokens to all
+holders during a split event.
+
+With the Token-2022 extension model, however, we have the possibility to change
+how the UI amount of tokens are represented. Using the `ScaledUiAmount`
+extension and the `amount_to_ui_amount` instruction, you can set a UI multiplier
+on your token and fetch its UI amount at any time.
+
+**Note**: No new tokens are ever created, the UI amount returns the raw amount
+of tokens multiplied by the current multiplier. The feature is entirely cosmetic.
+
+#### Example: Create a mint with a UI amount multiplier
+
+<Tabs groupId="language" items={['CLI', 'JS']}>
+  <Tab value="CLI">
+
+```console
+$ spl-token --program-id TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb create-token --ui-amount-multiplier 1.5
+Creating token 66EV4CaihdqyQ1fbsr51wBsoqKLgAG5KiYz7r5XNrxUM under program TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb
+
+Address:  66EV4CaihdqyQ1fbsr51wBsoqKLgAG5KiYz7r5XNrxUM
+Decimals:  9
+
+Signature: 2sPziXu9M3duTCvsDvxQE9UKC9nBiLayi8muDvnjhA2qYvfXSZuaUieoq39MFjg4kf8xFrw6crmYSkPyV59dvudF
+```
+
+  </Tab>
+  <Tab value="JS">
+
+```jsx
+import {
+    clusterApiUrl,
+    Connection,
+    Keypair,
+    sendAndConfirmTransaction,
+    SystemProgram,
+    Transaction,
+    LAMPORTS_PER_SOL
+} from '@solana/web3.js';
+import {
+    createInitializeMintInstruction,
+    createInitializeScaledUiAmountConfigInstruction,
+    getMintLen,
+    ExtensionType,
+    TOKEN_2022_PROGRAM_ID
+} from '../src';
+
+(async () => {
+    const connection = new Connection(clusterApiUrl('devnet'), 'confirmed');
+
+    const payer = Keypair.generate();
+    const airdropSignature = await connection.requestAirdrop(payer.publicKey, 2 * LAMPORTS_PER_SOL);
+    await connection.confirmTransaction({ signature: airdropSignature, ...(await connection.getLatestBlockhash()) });
+
+    const mintKeypair = Keypair.generate();
+    const decimals = 9;
+    const multiplier = 10.1;
+    const mintLen = getMintLen([ExtensionType.ScaledUiAmountConfig]);
+    const lamports = await connection.getMinimumBalanceForRentExemption(mintLen);
+    const transaction = new Transaction().add(
+        SystemProgram.createAccount({
+            fromPubkey: payer.publicKey,
+            newAccountPubkey: mintKeypair.publicKey,
+            space: mintLen,
+            lamports,
+            programId: TOKEN_2022_PROGRAM_ID,
+        }),
+        createInitializeScaledUiAmountConfigInstruction(mintKeypair.publicKey, payer.publicKey, multiplier, TOKEN_2022_PROGRAM_ID),
+        createInitializeMintInstruction(mintKeypair.publicKey, decimals, payer.publicKey, payer.publicKey, TOKEN_2022_PROGRAM_ID),
+    );
+    await sendAndConfirmTransaction(connection, transaction, [payer, mintKeypair]);
+})();
+```
+
+  </Tab>
+</Tabs>
+
+#### Example: Update the multiplier
+
+The multiplier authority may update the multiplier on the mint at any time, and
+optionally set a timestamp at which the new multiplier will take effect.
+
+<Tabs groupId="language" items={['CLI', 'JS']}>
+  <Tab value="CLI">
+
+```console
+$ spl-token update-ui-amount-multiplier 66EV4CaihdqyQ1fbsr51wBsoqKLgAG5KiYz7r5XNrxUM 10.5 1743000000
+Setting UI Multiplier for 66EV4CaihdqyQ1fbsr51wBsoqKLgAG5KiYz7r5XNrxUM to 10.5 at UNIX timestamp 1743000000
+
+Signature: 5DQs6hzkfGq3uotESuVwF7MGeMawwfQcm1e9RHaUeVySDV6xpUzYhzdb6ygqJfsEZqewgiDR5KuxaGzkdTMcDrTn
+```
+
+  </Tab>
+  <Tab value="JS">
+
+```jsx
+    const newMultiplier = 10.5;
+    const newMultiplierTimestamp = BigInt(1743000000);
+    await updateMultiplier(
+        connection,
+        payer,
+        mint,
+        authority,
+        newMultiplier,
+        newMultiplierTimestamp,
+        [],
+        undefined,
+        TOKEN_2022_PROGRAM_ID
+    );
+```
+
+  </Tab>
+</Tabs>

--- a/docs/content/docs/token-2022/extensions.mdx
+++ b/docs/content/docs/token-2022/extensions.mdx
@@ -1704,7 +1704,52 @@ Signature: 3ug4Ejs16jJgEm1WyBwDDxzh9xqPzQ3a2cmy1hSYiPFcLQi9U12HYF1Dbhzb2bx75SSyd
   </Tab>
   <Tab value="JS">
 
-Coming soon!
+```js
+import {
+  clusterApiUrl,
+  Connection,
+  Keypair,
+  LAMPORTS_PER_SOL,
+  sendAndConfirmTransaction,
+  SystemProgram,
+  Transaction,
+} from '@solana/web3.js';
+import {
+  createInitializeMetadataPointerInstruction,
+  createInitializeMintInstruction,
+  ExtensionType,
+  getMintLen,
+  TOKEN_2022_PROGRAM_ID,
+} from '@solana/spl-token';
+
+(async () => {
+  const payer = Keypair.generate();
+  const mint = Keypair.generate();
+  const decimals = 9;
+  const mintLen = getMintLen([ExtensionType.MetadataPointer]);
+
+  const connection = new Connection(clusterApiUrl('devnet'), 'confirmed');
+  const airdropSignature = await connection.requestAirdrop(payer.publicKey, 2 * LAMPORTS_PER_SOL);
+  await connection.confirmTransaction({
+    signature: airdropSignature,
+    ...(await connection.getLatestBlockhash()),
+  });
+
+  const mintLamports = await connection.getMinimumBalanceForRentExemption(mintLen);
+  const mintTransaction = new Transaction().add(
+    SystemProgram.createAccount({
+      fromPubkey: payer.publicKey,
+      newAccountPubkey: mint.publicKey,
+      space: mintLen,
+      lamports: mintLamports,
+      programId: TOKEN_2022_PROGRAM_ID,
+    }),
+    createInitializeMetadataPointerInstruction(mint.publicKey, payer.publicKey, mint.publicKey, TOKEN_2022_PROGRAM_ID),
+    createInitializeMintInstruction(mint.publicKey, decimals, payer.publicKey, null, TOKEN_2022_PROGRAM_ID),
+  );
+  await sendAndConfirmTransaction(connection, mintTransaction, [payer, mint]);
+})();
+```
 
   </Tab>
 </Tabs>
@@ -1949,7 +1994,59 @@ Signature: 3ug4Ejs16jJgEm1WyBwDDxzh9xqPzQ3a2cmy1hSYiPFcLQi9U12HYF1Dbhzb2bx75SSyd
   </Tab>
   <Tab value="JS">
 
-Coming soon!
+```jsx
+import {
+    clusterApiUrl,
+    Connection,
+    Keypair,
+    LAMPORTS_PER_SOL,
+    sendAndConfirmTransaction,
+    SystemProgram,
+    Transaction,
+} from '@solana/web3.js';
+import {
+    createInitializeGroupPointerInstruction,
+    createInitializeGroupMemberPointerInstruction,
+    createInitializeMintInstruction,
+    ExtensionType,
+    getMintLen,
+    TOKEN_2022_PROGRAM_ID,
+} from '@solana/spl-token';
+
+(async () => {
+    const payer = Keypair.generate();
+    const mint = Keypair.generate();
+    const decimals = 9;
+    const mintLen = getMintLen([ExtensionType.GroupPointer]);
+    const connection = new Connection(clusterApiUrl('devnet'), 'confirmed');
+
+    const airdropSignature = await connection.requestAirdrop(payer.publicKey, 2 * LAMPORTS_PER_SOL);
+    await connection.confirmTransaction({
+        signature: airdropSignature,
+        ...(await connection.getLatestBlockhash()),
+    });
+
+    const mintLamports = await connection.getMinimumBalanceForRentExemption(mintLen);
+    const mintTransaction = new Transaction().add(
+        SystemProgram.createAccount({
+            fromPubkey: payer.publicKey,
+            newAccountPubkey: mint.publicKey,
+            space: mintLen,
+            lamports: mintLamports,
+            programId: TOKEN_2022_PROGRAM_ID,
+        }),
+        createInitializeGroupPointerInstruction(
+            mint.publicKey,
+            payer.publicKey,
+            mint.publicKey,
+            TOKEN_2022_PROGRAM_ID,
+        ),
+        createInitializeMintInstruction(mint.publicKey, decimals, payer.publicKey, null, TOKEN_2022_PROGRAM_ID),
+    );
+    const sig = await sendAndConfirmTransaction(connection, mintTransaction, [payer, mint]);
+    console.log('Signature:', sig);
+})();
+```
 
   </Tab>
 </Tabs>
@@ -2026,7 +2123,58 @@ Signature: 3ug4Ejs16jJgEm1WyBwDDxzh9xqPzQ3a2cmy1hSYiPFcLQi9U12HYF1Dbhzb2bx75SSyd
   </Tab>
   <Tab value="JS">
 
-Coming soon!
+```jsx
+import {
+    clusterApiUrl,
+    Connection,
+    Keypair,
+    LAMPORTS_PER_SOL,
+    sendAndConfirmTransaction,
+    SystemProgram,
+    Transaction,
+} from '@solana/web3.js';
+import {
+    createInitializeGroupMemberPointerInstruction,
+    createInitializeMintInstruction,
+    ExtensionType,
+    getMintLen,
+    TOKEN_2022_PROGRAM_ID,
+} from '@solana/spl-token';
+
+(async () => {
+    const payer = Keypair.generate();
+    const mint = Keypair.generate();
+    const decimals = 9;
+    const mintLen = getMintLen([ExtensionType.GroupMemberPointer]);
+    const connection = new Connection(clusterApiUrl('devnet'), 'confirmed');
+
+    const airdropSignature = await connection.requestAirdrop(payer.publicKey, 2 * LAMPORTS_PER_SOL);
+    await connection.confirmTransaction({
+        signature: airdropSignature,
+        ...(await connection.getLatestBlockhash()),
+    });
+
+    const mintLamports = await connection.getMinimumBalanceForRentExemption(mintLen);
+    const mintTransaction = new Transaction().add(
+        SystemProgram.createAccount({
+            fromPubkey: payer.publicKey,
+            newAccountPubkey: mint.publicKey,
+            space: mintLen,
+            lamports: mintLamports,
+            programId: TOKEN_2022_PROGRAM_ID,
+        }),
+        createInitializeGroupMemberPointerInstruction(
+            mint.publicKey,
+            payer.publicKey,
+            mint.publicKey,
+            TOKEN_2022_PROGRAM_ID,
+        ),
+        createInitializeMintInstruction(mint.publicKey, decimals, payer.publicKey, null, TOKEN_2022_PROGRAM_ID),
+    );
+    const sig = await sendAndConfirmTransaction(connection, mintTransaction, [payer, mint]);
+    console.log('Signature:', sig);
+})();
+```
 
   </Tab>
 </Tabs>

--- a/docs/content/docs/token-2022/index.md
+++ b/docs/content/docs/token-2022/index.md
@@ -136,11 +136,13 @@ For information about the types and instructions, the Rust docs are available at
 The Token-2022 Program has been audited multiple times. All audits are published
 here as they are completed.
 
-Here are the completed audits as of 13 December 2023:
+Here are the completed audits as of 20 March 2025:
 
 * Halborn
     - Review commit hash [`c3137a`](https://github.com/solana-labs/solana-program-library/tree/c3137af9dfa2cc0873cc84c4418dea88ac542965/token/program-2022)
     - Final report https://github.com/anza-xyz/security-audits/blob/master/spl/HalbornToken2022Audit-2022-07-27.pdf
+    - Review commit hash [`56aaa6`](https://github.com/solana-labs/solana-program-library/commit/56aaa6732670824273414bb14bbea12c83a46829/token/program-2022)
+    - Final report https://github.com/anza-xyz/security-audits/blob/master/spl/HalbornToken2022Audit-2024-03-08.pdf
 * Zellic
     - Review commit hash [`54695b`](https://github.com/solana-labs/solana-program-library/tree/54695b233484722458b18c0e26ebb8334f98422c/token/program-2022)
     - Final report https://github.com/anza-xyz/security-audits/blob/master/spl/ZellicToken2022Audit-2022-12-05.pdf
@@ -156,3 +158,6 @@ Here are the completed audits as of 13 December 2023:
 * OtterSec (ZK Token SDK)
     - Review commit hash [`9e703f8`](https://github.com/solana-labs/solana/tree/9e703f8/zk-token-sdk)
     - Final report https://github.com/anza-xyz/security-audits/blob/master/spl/OtterSecZkTokenSdkAudit-2023-11-04.pdf
+* Certora
+    - Review commit hash [`260f80`](https://github.com/solana-labs/solana-program-library/tree/260f80928f796fc78c81efa4dc2a7732665e5a59)
+    - Final report https://github.com/anza-xyz/security-audits/blob/master/spl/CertoraToken2022Audit-2024-05-24.pdf

--- a/docs/content/docs/token-2022/index.md
+++ b/docs/content/docs/token-2022/index.md
@@ -85,6 +85,7 @@ You can read more about how this is done at the
 Mint extensions currently include:
 
 * confidential transfers
+* confidential mint-burn
 * transfer fees
 * closing mint
 * interest-bearing tokens

--- a/docs/content/docs/token-2022/index.md
+++ b/docs/content/docs/token-2022/index.md
@@ -93,6 +93,12 @@ Mint extensions currently include:
 * transfer hook
 * metadata pointer
 * metadata
+* group pointer
+* group
+* group member pointer
+* group member
+* scaled UI amount
+* pausable
 
 Account extensions currently include:
 


### PR DESCRIPTION
#### Problem

There are some undocumented extensions in the solana-program docs.

#### Summary of changes

Although the change is a bit big, it can be read commit-by-commit.

* 3a5b0ef98fa16b513190ee31fcce9ec9db5d4a18: Add JS examples to use metadata / group pointer
* 3ec908e8dd2ef32749d92cdaa0144d3ba1a2d6ab: Add new audits
* 91890cd7e837e6cd5acf053d34e0665c080758ba: Add docs for scaled ui amount
* 5c6d8a059140305b802e710b5796c99b000b6efd: Add docs for pausable extension
* 3dfd70c552055fa36b6aafa52c03221959b3a920: Update the extension list

@gitteri -- do you mind giving this a review?