### PR TITLE
token-2022: Clarify when transfer hooks are not called

### DIFF
--- a/docs/content/docs/token-2022/extensions.mdx
+++ b/docs/content/docs/token-2022/extensions.mdx
@@ -1536,6 +1536,9 @@ the program may require are automatically resolved on-chain! This process is
 explained in detail in many of the linked `README` files below under
 **Resources**.
 
+**Note**: The transfer-hook program is not called during self-transfers, where
+the source and destination accounts are the same.
+
 #### Resources
 
 The interface description and structs exist at


### PR DESCRIPTION
#### Problem

It's not clear that the transfer hook is not called during self-transfers.

#### Summary of changes

Make it abundantly clear.

Closes https://github.com/solana-program/token-2022/issues/1109

cc @gitteri