### PR TITLE
docs: Refresh confidential balances status and CLI links

### DIFF
--- a/docs/content/docs/confidential-balances/index.md
+++ b/docs/content/docs/confidential-balances/index.md
@@ -15,9 +15,9 @@ See the [Token Setup Guide](/docs/token#setup) to install the client utilities.
 Token-2022 shares the same CLI and NPM packages for maximal compatibility.
 
 All of the commands here exist in a
-[helper script](https://github.com/solana-labs/solana-program-library/tree/master/token/cli/examples/confidential-transfer.sh)
+[helper script](https://github.com/solana-program/token-2022/blob/main/clients/cli/examples/confidential-transfer.sh)
 at the
-[Token CLI Examples](https://github.com/solana-labs/solana-program-library/tree/master/token/cli/examples).
+[Token CLI Examples](https://github.com/solana-program/token-2022/tree/main/clients/cli/examples).
 
 ### Example: Create a mint with confidential transfers
 
@@ -37,6 +37,25 @@ the token non-confidentially.
 
 Note that you must configure your mint with confidential transfers at creation,
 and cannot add it later.
+
+### Example: Set a global auditor
+
+Confidential transfers hide amounts from the public, but issuers in regulated
+environments often need a way to inspect them. The confidential transfer
+extension supports an optional _global auditor_: an ElGamal public key stored on
+the mint. When set, every confidential transfer must additionally encrypt its
+amount under the auditor's key, allowing the holder of the corresponding secret
+key to decrypt all transfer amounts for that mint.
+
+The confidential transfer authority can set or update the auditor key with:
+
+```console
+$ spl-token update-confidential-transfer-settings <MINT_PUBKEY> --auditor-pubkey <AUDITOR_ELGAMAL_PUBKEY>
+```
+
+The auditor key is supplied as a base64 encoding of an ElGamal public key. Pass
+`--auditor-pubkey none` to remove the auditor. See the
+[overview](/docs/confidential-balances/overview) for more on the auditor model.
 
 ### Example: Configure a token account for confidential transfers
 

--- a/docs/content/docs/token-2022/status.md
+++ b/docs/content/docs/token-2022/status.md
@@ -2,33 +2,20 @@
 title: Project Status
 ---
 
-All clusters have the latest program deployed **without confidential transfer
-functionality**.
+All clusters have the latest Token-2022 program deployed, including confidential
+transfer functionality.
 
-The program with confidential transfer functionality will be deployed once
-Agave v2.0 reaches mainnet-beta with the appropriate cluster features enabled.
+Confidential transfers depend on the [ZK ElGamal Proof
+Program](https://docs.anza.xyz/runtime/zk-elgamal-proof), which performs the
+on-chain verification of the zero-knowledge proofs used by the confidential
+extensions. Using confidential tokens requires a cluster running a version of
+the runtime with that program enabled.
 
-## Timeline
+## Upgradability
 
-Here is the general program timeline and rough ETAs:
-
-| Issue                       | ETA                            |
-| --------------------------- | ------------------------------ |
-| Mainnet recommendation      | Winter 2024 (depends on v1.17) |
-| Token group extension       | Summer 2024                    |
-| Confidential transfers      | Autumn 2024 (depends on v2.0)  |
-| Freeze program              | 2025                           |
-
-More information: https://github.com/orgs/solana-labs/projects/34
-
-## Remaining items
-
-### v2.0 with ZK ElGamal Proof Program
-
-In order to use confidential tokens, the cluster must run at least version 2.0
-with the ZK ElGamal Proof Program enabled.
-
-More information: https://github.com/anza-xyz/agave/issues/1966
+To facilitate deploying updates and security fixes, the program deployment remains
+upgradable. Once audits are complete and the program has been stable for six months,
+the deployment will be marked final and no further upgrades will be possible.
 
 ## Future work
 
@@ -37,19 +24,6 @@ More information: https://github.com/anza-xyz/agave/issues/1966
 To start, wallets need to properly handle the Token-2022 program and its accounts,
 by fetching Token-2022 accounts and sending instructions to the proper program.
 
-Next, to use confidential tokens, wallets need to create zero-knowledge proofs,
-which entails a new transaction flow.
-
-### Increased transaction size
-
-To support confidential transfers in one transaction, rather than split up over
-multiple transactions, the Solana network must accept transactions with a larger
-payload.
-
-More information: https://github.com/orgs/solana-labs/projects/16
-
-## Upgradability
-
-To facilitate deploying updates and security fixes, the program deployment remains
-upgradable. Once audits are complete and the program has been stable for six months,
-the deployment will be marked final and no further upgrades will be possible.
+To use confidential tokens, wallets additionally need to create zero-knowledge
+proofs, which entails a new transaction flow. See the [Confidential Balances
+guide](/docs/confidential-balances) for the full flow.


### PR DESCRIPTION
Quick cleanup of stale confidential balances docs (first of two PRs, the second adds confidential mint/burn and confidential transfer fee pages).

- **status.md**: rewrote the project status page. It still claimed the program was deployed *without* confidential transfer functionality and listed Autumn 2024 ETAs. Now reflects that confidential transfers ship with the program, keeps the ZK ElGamal Proof Program dependency note, and drops the outdated timeline table.
- **confidential-balances/index.md**: fixed dead CLI example links (code moved from the archived solana-labs/solana-program-library to solana-program/token-2022) and added a global auditor setup example using update-confidential-transfer-settings --auditor-pubkey.