### PR TITLE
docs: Add confidential mint/burn and confidential transfer fee pages

### DIFF
--- a/docs/content/docs/confidential-balances/mint-burn.md
+++ b/docs/content/docs/confidential-balances/mint-burn.md
@@ -1,0 +1,96 @@
+---
+title: Confidential Mint and Burn
+description: Keep a Token-2022 mint's supply confidential by minting and burning directly against confidential balances.
+---
+
+The base [confidential balances](/docs/confidential-balances) feature keeps
+individual account balances and transfer amounts private, but the mint's total
+supply is still public: tokens enter the confidential system through a public
+`deposit` and leave through a public `withdraw`, both of which move a cleartext
+amount between the public and confidential balances.
+
+For some issuers that is not enough. A stablecoin or tokenized asset issuer may
+want the amount they mint and burn, and therefore the total supply in
+circulation, to stay private as well. The `ConfidentialMintBurn` extension makes
+this possible.
+
+## What it does
+
+When a mint enables the confidential mint/burn extension, the authority mints new
+tokens directly into a recipient's confidential balance and burns tokens directly
+from a confidential balance. The amounts are encrypted, and the mint tracks an
+**encrypted total supply** rather than a public one.
+
+Because issuance and redemption now happen entirely inside the confidential
+system, the public conversion path is disabled: `deposit` and `withdraw`
+instructions are rejected on a mint that has this extension. Tokens only ever
+exist confidentially, so there is no cleartext supply to observe.
+
+Like the other confidential extensions, it must be initialized at mint creation
+and cannot be added later.
+
+## Mint state
+
+The extension stores the supply confidentially on the mint:
+
+- **Confidential supply**: the encrypted total supply, encrypted under the mint's
+  supply ElGamal public key.
+- **Decryptable supply**: an authenticated symmetric (AES) ciphertext of the
+  supply, so the authority can read the current supply efficiently without
+  solving a discrete log.
+- **Supply ElGamal public key**: the key the confidential supply is encrypted
+  under.
+- **Pending burn**: burned amounts that have not yet been aggregated into the
+  confidential supply (see [applying pending burns](#applying-pending-burns)).
+
+## Operations
+
+All amount-carrying operations require zero-knowledge proofs, supplied either in
+the same transaction or pre-verified into proof context state accounts, exactly
+as with confidential transfers.
+
+### Minting
+
+The mint authority mints an encrypted amount into a recipient's confidential
+pending balance. The recipient applies their pending balance to make the funds
+available, just like receiving a confidential transfer. The minted amount is
+homomorphically added to the encrypted supply.
+
+### Burning
+
+A holder burns an encrypted amount from their confidential available balance. The
+burned amount accumulates in the mint's **pending burn** field rather than being
+subtracted from the supply immediately.
+
+### Applying pending burns
+
+Burns are aggregated into the confidential supply in a separate step. The
+`ApplyPendingBurn` instruction folds the accumulated pending burn into the
+confidential supply, mirroring the pending/available model used for account
+balances. This keeps burning cheap and lets the supply be reconciled
+periodically.
+
+### Rotating the supply key
+
+The supply encryption key can be rotated with `RotateSupplyElGamalPubkey`, which
+re-encrypts the confidential supply under a new ElGamal key and proves, with a
+ciphertext-ciphertext equality proof, that the encrypted value did not change.
+The pending burn must be zero before rotating.
+
+### Updating the decryptable supply
+
+`UpdateDecryptableSupply` refreshes the AES ciphertext of the supply, for example
+after the authority changes the symmetric key used to read it.
+
+## Closing the mint
+
+A mint with this extension can only be closed once its confidential supply is the
+zero ciphertext. If the supply encrypts zero but is not an identically-zero
+ciphertext, rotate the supply key first to normalize it, then close the mint.
+
+## Relationship to permissioned burn
+
+The [permissioned burn](/docs/token-2022/extensions#permissioned-burn) extension
+also has a confidential burn path. When both extensions are present, a
+confidential burn must additionally be co-signed by the mint's configured
+permissioned burn authority.

--- a/docs/content/docs/confidential-balances/transfer-fee.md
+++ b/docs/content/docs/confidential-balances/transfer-fee.md
@@ -1,0 +1,63 @@
+---
+title: Confidential Transfer Fees
+description: Collect Token-2022 transfer fees on confidential transfers without revealing the fee or transfer amount.
+---
+
+The [transfer fee](/docs/token-2022/extensions#transfer-fees) extension lets a
+mint charge a fee on every transfer. The fee is withheld on the recipient's
+account, harvested to the mint, and later withdrawn by the fee authority.
+
+That flow assumes the transfer amount is public: the program computes the fee
+from the cleartext amount. When transfers are [confidential](/docs/confidential-balances),
+the amount is encrypted, so the fee has to be handled confidentially too. The
+`ConfidentialTransferFeeConfig` extension provides this. It is used alongside the
+regular transfer fee extension on mints that also enable confidential transfers.
+
+## What it does
+
+On a confidential transfer, the fee is computed and withheld as an **encrypted
+amount**. Withheld fees accumulate confidentially on the accounts that received
+transfers, then follow the same harvest-then-withdraw lifecycle as ordinary
+transfer fees, except every fee amount stays encrypted along the way.
+
+Like the other confidential extensions, it must be initialized at mint creation
+and cannot be added later.
+
+## State
+
+- **Mint** (`ConfidentialTransferFeeConfig`):
+  - A withdraw-withheld-authority ElGamal public key. Withheld fees are encrypted
+    under this key, so whoever holds the corresponding secret key can decrypt
+    withheld fee amounts. Combined with the public fee parameters, this can reveal
+    information about transfer amounts, so treat the key accordingly.
+  - A `harvest_to_mint_enabled` flag controlling whether accounts may harvest
+    their withheld fees to the mint.
+  - The encrypted total of fees that have been harvested to the mint and are
+    awaiting withdrawal.
+- **Token account** (`ConfidentialTransferFeeAmount`): the encrypted fee withheld
+  on that account, waiting to be harvested to the mint.
+
+## Lifecycle
+
+The flow mirrors the non-confidential transfer fee flow:
+
+1. **Withhold on transfer**: each confidential transfer encrypts the fee and adds
+   it to the destination account's withheld balance.
+2. **Harvest to mint**: `HarvestWithheldTokensToMint` is a permissionless
+   instruction that moves the encrypted withheld fees from accounts into the
+   mint. It succeeds even for frozen accounts. The mint authority can turn this on
+   or off for the mint with `EnableHarvestToMint` and `DisableHarvestToMint`.
+3. **Withdraw from the mint**: the withdraw-withheld authority moves the harvested
+   fees out of the mint with `WithdrawWithheldTokensFromMint`.
+4. **Withdraw directly from accounts**: the authority can also pull withheld fees
+   straight from accounts with `WithdrawWithheldTokensFromAccounts`, skipping the
+   harvest step.
+
+Withdrawals require zero-knowledge proofs, supplied in the same transaction or
+pre-verified into proof context state accounts, just like confidential transfers.
+
+> **Front-running note**: withdrawing withheld fees from accounts depends on the
+> encrypted withheld amount at the time the proof is generated. If new transfers
+> add to an account's withheld fees between proof generation and execution, the
+> withdraw can fail. Harvesting to the mint first, then withdrawing from the mint,
+> avoids this race.


### PR DESCRIPTION
Second of two PRs cleaning up confidential balances docs (first is #30). Adds conceptual guides for two confidential extensions that weren't documented anywhere.

**Confidential mint/burn** (mint-burn.md): how a mint keeps its total supply encrypted by minting and burning directly against confidential balances, which disables the public deposit/withdraw conversion path. Covers the encrypted supply state (confidential supply, decryptable supply, supply ElGamal key, pending burn), the mint/burn/apply-pending-burn flow, supply key rotation, and the zero-ciphertext condition for closing the mint.

**Confidential transfer fee** (transfer-fee.md): how transfer fees are withheld, harvested to the mint, and withdrawn confidentially when the transfer amount is itself encrypted, plus the front-running note on withdrawing directly from accounts.

Both pages are conceptual rather than example-driven: these features currently have no CLI subcommands or js-legacy client support, so they live at the program/Rust-client level. Content is grounded in the extension code in solana-program/token-2022 (interface/src/extension/confidential_mint_burn and confidential_transfer_fee). The mint/burn page cross-links to the permissioned burn section added in #29.