### PR TITLE
Add 'permissioned burn' to token-2022 documentation

### DIFF
--- a/docs/content/docs/token-2022/index.md
+++ b/docs/content/docs/token-2022/index.md
@@ -99,6 +99,7 @@ Mint extensions currently include:
 * group member pointer
 * group member
 * scaled UI amount
+* permissioned burn
 * pausable
 
 Account extensions currently include:


### PR DESCRIPTION
Small update to add permissioned burn to the list of extensions on token 2022